### PR TITLE
Change MASTER by MAIN in branches section

### DIFF
--- a/contribute/RULES.md
+++ b/contribute/RULES.md
@@ -34,7 +34,7 @@ To request such access, you shall create a ticket under the [collaborative-envir
 
 ## Branches
 
-In a repository the **master** branch is reserved for the IVV team. 
+In a repository the **main** branch is reserved for the IVV team. 
 
 ## Development 
 


### PR DESCRIPTION
It is a specificity of Github. Usually, in git project, the main branch is MASTER. It may be interesting to add a comment to indicate this difference.