### PR TITLE
Update operational procedure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Let's start by installing the mandatory base of our system:
 
 ### Usage
 
-To use the Reference System Software you can follow the [operationnal producedures](https://github.com/COPRS/reference-system-software/blob/main/releases/V2.0.0.md). 
+To use the Reference System Software you can follow the [operationnal producedures](https://github.com/COPRS/infrastructure/tree/main/docs/user_manuals). 
 
 ## Contribute to the project
 


### PR DESCRIPTION
The operational procedure refers to the How-to procedure.

Do we prefere having the link to:
1- The [User's Manual](https://github.com/COPRS/infrastructure/tree/main/docs/user_manuals) page:
![image](https://github.com/COPRS/reference-system-software/assets/28825797/231f8633-a3b6-4176-bbea-78319835eb38)

2- The [folder ](https://github.com/COPRS/infrastructure/tree/main/docs/user_manuals/how-to)with all the procedures:
![image](https://github.com/COPRS/reference-system-software/assets/28825797/deacee26-2b2f-471f-997f-8d6bd4a08407)

In my point of view, it is more readable to have the link to a markdown file rather than folder. 
So I the proposed the solution 1 in the change.